### PR TITLE
update link to melpa on init.el

### DIFF
--- a/init.el
+++ b/init.el
@@ -21,7 +21,7 @@
 
 ;; Add melpa to package archives.
 (add-to-list 'package-archives
-             '("melpa" . "http://melpa.milkbox.net/packages/") t)
+             '("melpa" . "https://melpa.org/packages/") t)
 
 ;; Load and activate emacs packages. Do this first so that the packages are loaded before
 ;; you start trying to modify them.  This also sets the load path.


### PR DESCRIPTION
When I tried to update some packages it was failing recently and it was because the link to Melpa earlier now throws a 404. 
